### PR TITLE
Fix support for --cpu in generate.py

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
 
   # Load the best saved model.
   with open(model_fp, 'rb') as f:
-    model = torch.load(f)
+    model = torch.load(f, map_location=device)
   model.backward_compatible()
   model = model.to(device)
 

--- a/model/utils/proj_adaptive_softmax.py
+++ b/model/utils/proj_adaptive_softmax.py
@@ -6,9 +6,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-CUDA_MAJOR = int(torch.version.cuda.split('.')[0])
-CUDA_MINOR = int(torch.version.cuda.split('.')[1])
-
 class ProjectedAdaptiveLogSoftmax(nn.Module):
     def __init__(self, n_token, d_embed, d_proj, cutoffs, div_val=1,
                  keep_order=False):
@@ -60,13 +57,8 @@ class ProjectedAdaptiveLogSoftmax(nn.Module):
         if proj is None:
             logit = F.linear(hidden, weight, bias=bias)
         else:
-            # if CUDA_MAJOR <= 9 and CUDA_MINOR <= 1:
             proj_hid = F.linear(hidden, proj.t().contiguous())
             logit = F.linear(proj_hid, weight, bias=bias)
-            # else:
-            #     logit = torch.einsum('bd,de,ev->bv', (hidden, proj, weight.t()))
-            #     if bias is not None:
-            #         logit = logit + bias
 
         return logit
 


### PR DESCRIPTION
If the --cpu command line option is set, make sure we pass it propery to
torch.load() so that if the system doesn't have CUDA, it uses the CPU.
In order to do so, add the `map_location` parameter.

Additionally, remove the unused `CUDA_MAJOR` and `CUDA_MINOR`
variables in proj_adaptive_softmax.py .